### PR TITLE
[Bugfix] Fix payload generation for guzzle requests

### DIFF
--- a/src/Requests/Payload.php
+++ b/src/Requests/Payload.php
@@ -49,7 +49,7 @@ class Payload
             'method' => $this->request->getMethod(),
             'timestamp' => $timestamp,
             'uri' => (string) $this->request->getUri(),
-            'content' => $this->request->getBody()
+            'content' => $this->request->getBody()->getContents()
         ], JSON_UNESCAPED_SLASHES);
     }
 

--- a/tests/Requests/PayloadTest.php
+++ b/tests/Requests/PayloadTest.php
@@ -40,6 +40,32 @@ class PayloadTest extends TestCase
     /**
      * @test
      */
+    public function it_translates_a_guzzle_request_with_content_to_a_json_encoded_string()
+    {
+        $now = (string) Carbon::now();
+
+        $method = 'GET';
+        $uri = 'https://localhost';
+        $id = Uuid::uuid4();
+
+        $request = (new GuzzleRequest('GET', 'https://localhost', [], 'content'))
+            ->withHeader('X-SIGNED-ID', $id)
+            ->withHeader('X-SIGNED-TIMESTAMP', $now);
+
+        $expected = json_encode([
+            'id' => $id,
+            'method' => $method,
+            'timestamp' => $now,
+            'uri' => $uri,
+            'content' => 'content'
+        ], JSON_UNESCAPED_SLASHES);
+
+        $this->assertEquals($expected, (string) new Payload($request));
+    }
+
+    /**
+     * @test
+     */
     public function it_translates_an_illuminate_request_to_a_json_encoded_string()
     {
         $now = (string) Carbon::now();

--- a/tests/Requests/PayloadTest.php
+++ b/tests/Requests/PayloadTest.php
@@ -31,7 +31,7 @@ class PayloadTest extends TestCase
             'method' => $method,
             'timestamp' => $now,
             'uri' => $uri,
-            'content' => $request->getBody()
+            'content' => $request->getBody()->getContents()
         ], JSON_UNESCAPED_SLASHES);
 
         $this->assertEquals($expected, (string) new Payload($request));


### PR DESCRIPTION
The `getBody` method returns a stream object. Calling `getContents` on the stream will return the string contents.