### PR TITLE
[Change] Update the instructions to only publish the resources from this package

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ Open `config/app.php` and register the required service provider above your appl
 ### Publish the Configuration
 
 ```php
-php artisan vendor:publish
+php artisan vendor:publish --provider 'SoapBox\SignedRequests\ServiceProvider'
 ```
 
 ### Configuring your Environment


### PR DESCRIPTION
This will prevent the `vendor:publish` command from copying over a bunch of file from other packages as well. Running this locally was copying over a bunch of email related files from Laravel.