### PR TITLE
[Feature] Decouple the Generators from the Illuminate Configuration Repository

### DIFF
--- a/src/Configurations/Configuration.php
+++ b/src/Configurations/Configuration.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SoapBox\SignedRequests\Configurations;
+
+interface Configuration
+{
+    /**
+     * Returns the name of the header that will contain the algorithm used to
+     * sign the request.
+     *
+     * @return string
+     */
+    public function getAlgorithmHeader(): string;
+
+    /**
+     * Returns the name of the header that will contain the generated signature.
+     *
+     * @return string
+     */
+    public function getSignatureHeader(): string;
+
+    /**
+     * Returns the algorithm to use to generate the signature.
+     *
+     * @return string
+     */
+    public function getSigningAlgorithm(): string;
+
+    /**
+     * Returns the key to sign the request with.
+     *
+     * @return string
+     */
+    public function getSigningKey(): string;
+}

--- a/src/Configurations/CustomConfiguration.php
+++ b/src/Configurations/CustomConfiguration.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace SoapBox\SignedRequests\Configurations;
+
+class CustomConfiguration implements Configuration
+{
+    /**
+     * The algorithm header to return.
+     *
+     * @var string
+     */
+    protected $algorithmHeader;
+
+    /**
+     * The signature header to return.
+     *
+     * @var string
+     */
+    protected $signatureHeader;
+
+    /**
+     * The signing algorithm to return.
+     *
+     * @var string
+     */
+    protected $signingAlgorithm;
+
+    /**
+     * The signing key to return.
+     *
+     * @var string
+     */
+    protected $signingKey;
+
+    /**
+     * Sets up our custom configuration with various properties.
+     *
+     * @param string $algorithmHeader
+     *        The algorithm header to use.
+     * @param string $signatureHeader
+     *        The signature header to use.
+     * @param string $signingAlgorithm
+     *        The signing algorithm to use.
+     * @param string $signingKey
+     *        The signing key to use.
+     */
+    public function __construct(
+        string $algorithmHeader,
+        string $signatureHeader,
+        string $signingAlgorithm,
+        string $signingKey
+    ) {
+        $this->algorithmHeader = $algorithmHeader;
+        $this->signatureHeader = $signatureHeader;
+        $this->signingAlgorithm = $signingAlgorithm;
+        $this->signingKey = $signingKey;
+    }
+
+    /**
+     * Returns the name of the header that will contain the algorithm used to
+     * sign the request.
+     *
+     * @return string
+     */
+    public function getAlgorithmHeader(): string
+    {
+        return $this->algorithmHeader;
+    }
+
+    /**
+     * Returns the name of the header that will contain the generated signature.
+     *
+     * @return string
+     */
+    public function getSignatureHeader(): string
+    {
+        return $this->signatureHeader;
+    }
+
+    /**
+     * Returns the algorithm to use to generate the signature.
+     *
+     * @return string
+     */
+    public function getSigningAlgorithm(): string
+    {
+        return $this->signingAlgorithm;
+    }
+
+    /**
+     * Returns the key to sign the request with.
+     *
+     * @return string
+     */
+    public function getSigningKey(): string
+    {
+        return $this->signingKey;
+    }
+}

--- a/src/Configurations/RepositoryConfiguration.php
+++ b/src/Configurations/RepositoryConfiguration.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace SoapBox\SignedRequests\Configurations;
+
+use Illuminate\Contracts\Config\Repository;
+
+class RepositoryConfiguration implements Configuration
+{
+    /**
+     * An instance of the configuration repository.
+     *
+     * @var \Illuminate\Contracts\Config\Repository
+     */
+    protected $repository;
+
+    /**
+     * Sets up our configuration with an instance of the laravel configuration
+     * repository.
+     *
+     * @param \Illuminate\Contracts\Config\Repository $repository
+     *        A configuration repository.
+     */
+    public function __construct(Repository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * Returns the name of the header that will contain the algorithm used to
+     * sign the request.
+     *
+     * @return string
+     */
+    public function getAlgorithmHeader(): string
+    {
+        return $this->repository->get('signed-requests.headers.algorithm');
+    }
+
+    /**
+     * Returns the name of the header that will contain the generated signature.
+     *
+     * @return string
+     */
+    public function getSignatureHeader(): string
+    {
+        return $this->repository->get('signed-requests.headers.signature');
+    }
+
+    /**
+     * Returns the algorithm to use to generate the signature.
+     *
+     * @return string
+     */
+    public function getSigningAlgorithm(): string
+    {
+        return $this->repository->get('signed-requests.algorithm');
+    }
+
+    /**
+     * Returns the key to sign the request with.
+     *
+     * @return string
+     */
+    public function getSigningKey(): string
+    {
+        return $this->repository->get('signed-requests.key');
+    }
+}

--- a/src/Exceptions/ExpiredRequestException.php
+++ b/src/Exceptions/ExpiredRequestException.php
@@ -3,7 +3,6 @@
 namespace SoapBox\SignedRequests\Exceptions;
 
 use Exception;
-use Throwable;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 

--- a/src/Exceptions/InvalidSignatureException.php
+++ b/src/Exceptions/InvalidSignatureException.php
@@ -3,7 +3,6 @@
 namespace SoapBox\SignedRequests\Exceptions;
 
 use Exception;
-use Throwable;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 

--- a/src/Middlewares/Guzzle/GenerateSignature.php
+++ b/src/Middlewares/Guzzle/GenerateSignature.php
@@ -4,6 +4,7 @@ namespace SoapBox\SignedRequests\Middlewares\Guzzle;
 
 use Psr\Http\Message\RequestInterface;
 use SoapBox\SignedRequests\Requests\Generator;
+use SoapBox\SignedRequests\Configurations\Configuration;
 
 class GenerateSignature
 {
@@ -15,14 +16,14 @@ class GenerateSignature
     protected $generator;
 
     /**
-     * Expect an instance of the generator so we can sign the request
+     * Expect a configuration to build our generator with.
      *
-     * @param \SoapBox\SignedRequests\Requests\Generator $generator
-     *        An instance of the signed request generator
+     * @param \SoapBox\SignedRequests\Configurations\Configuration $configuration
+     *        The configuration to use for generating signed requests.
      */
-    public function __construct(Generator $generator)
+    public function __construct(Configuration $configuration)
     {
-        $this->generator = $generator;
+        $this->generator = new Generator($configuration);
     }
 
     /**

--- a/src/Requests/Generator.php
+++ b/src/Requests/Generator.php
@@ -6,8 +6,6 @@ use Carbon\Carbon;
 use Ramsey\Uuid\Uuid;
 use GuzzleHttp\Psr7\Request;
 use SoapBox\SignedRequests\Signature;
-use Illuminate\Support\Facades\Config;
-use Illuminate\Contracts\Config\Repository;
 use SoapBox\SignedRequests\Configurations\Configuration;
 
 class Generator

--- a/src/Requests/Generator.php
+++ b/src/Requests/Generator.php
@@ -8,26 +8,27 @@ use GuzzleHttp\Psr7\Request;
 use SoapBox\SignedRequests\Signature;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Contracts\Config\Repository;
+use SoapBox\SignedRequests\Configurations\Configuration;
 
 class Generator
 {
     /**
-     * An instance of the configuration repository.
+     * A configuration to use for generating signatures.
      *
-     * @var \Illuminate\Contracts\Config\Repository
+     * @var \SoapBox\SignedRequests\Configurations\Configuration
      */
-    private $repository;
+    private $configuration;
 
     /**
      * Constructs our signed request generator with an instance of the
      * configurations.
      *
-     * @param \Illuminate\Contracts\Config\Repository $repository
-     *        A configuration repository.
+     * @param \SoapBox\SignedRequests\Configurations\Configuration $configuration
+     *        The configuration to use for generating the signed request.
      */
-    public function __construct(Repository $repository)
+    public function __construct(Configuration $configuration)
     {
-        $this->repository = $repository;
+        $this->configuration = $configuration;
     }
 
     /**
@@ -37,15 +38,15 @@ class Generator
      *        The request to sign.
      *
      * @return \GuzzleHttp\Psr7\Request
-     *         The request with an id, algorith, and signature.
+     *         The request with an id, algorithm, and signature.
      */
     public function sign(Request $request) : Request
     {
-        $algorithmHeader = $this->repository->get('signed-requests.headers.algorithm');
-        $signatureHeader = $this->repository->get('signed-requests.headers.signature');
+        $algorithmHeader = $this->configuration->getAlgorithmHeader();
+        $signatureHeader = $this->configuration->getSignatureHeader();
 
-        $algorithm = $this->repository->get('signed-requests.algorithm');
-        $key = $this->repository->get('signed-requests.key');
+        $algorithm = $this->configuration->getSigningAlgorithm();
+        $key = $this->configuration->getSigningKey();
 
         $request = $request->withHeader('X-SIGNED-ID', (string) Uuid::uuid4());
         $request = $request->withHeader('X-SIGNED-TIMESTAMP', (string) Carbon::now());

--- a/src/Requests/Verifier.php
+++ b/src/Requests/Verifier.php
@@ -5,7 +5,6 @@ namespace SoapBox\SignedRequests\Requests;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use SoapBox\SignedRequests\Signature;
-use SoapBox\SignedRequests\Requests\Payload;
 
 class Verifier
 {

--- a/tests/Configurations/CustomConfigurationTest.php
+++ b/tests/Configurations/CustomConfigurationTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Configurations;
+
+use Tests\TestCase;
+use SoapBox\SignedRequests\Configurations\CustomConfiguration;
+
+class CustomConfigurationTest extends TestCase
+{
+    /**
+     * @test
+     */
+    function it_returns_the_set_values_when_requested()
+    {
+        $algorithmHeader = 'a';
+        $signatureHeader = 's';
+        $signingAlgorithm = 'sa';
+        $signingKey = 'sk';
+
+        $configuration = new CustomConfiguration(
+            $algorithmHeader,
+            $signatureHeader,
+            $signingAlgorithm,
+            $signingKey
+        );
+
+        $this->assertSame($algorithmHeader, $configuration->getAlgorithmHeader());
+        $this->assertSame($signatureHeader, $configuration->getSignatureHeader());
+        $this->assertSame($signingAlgorithm, $configuration->getSigningAlgorithm());
+        $this->assertSame($signingKey, $configuration->getSigningKey());
+    }
+}

--- a/tests/Configurations/RepositoryConfigurationTest.php
+++ b/tests/Configurations/RepositoryConfigurationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Configurations;
+
+use Mockery;
+use Tests\TestCase;
+use Illuminate\Contracts\Config\Repository;
+use SoapBox\SignedRequests\Configurations\RepositoryConfiguration;
+
+class RepositoryConfigurationTest extends TestCase
+{
+    protected $repository;
+    protected $configuration;
+
+    /**
+     * @before
+     */
+    function setup_repository()
+    {
+        $this->repository = Mockery::mock(Repository::class);
+        $this->configuration = new RepositoryConfiguration($this->repository);
+    }
+
+    /**
+     * @test
+     */
+    function get_algorithm_header_returns_the_algorithm_header_value_from_the_configuration_repository()
+    {
+        $this->repository->shouldReceive('get')
+            ->with('signed-requests.headers.algorithm')
+            ->andReturn('algorithm');
+
+        $this->assertSame('algorithm', $this->configuration->getAlgorithmHeader());
+    }
+
+    /**
+     * @test
+     */
+    function get_signature_header_returns_the_signature_header_value_from_the_configuration_repository()
+    {
+        $this->repository->shouldReceive('get')
+            ->with('signed-requests.headers.signature')
+            ->andReturn('signature');
+
+        $this->assertSame('signature', $this->configuration->getSignatureHeader());
+    }
+
+    /**
+     * @test
+     */
+    function get_signing_algorithm_returns_the_signing_algorithm_to_use_from_the_configuration_repository()
+    {
+        $this->repository->shouldReceive('get')
+            ->with('signed-requests.algorithm')
+            ->andReturn('sha256');
+
+        $this->assertSame('sha256', $this->configuration->getSigningAlgorithm());
+    }
+
+    /**
+     * @test
+     */
+    function get_signing_key_returns_the_key_used_for_signing_the_request_from_the_configuration_repository()
+    {
+        $this->repository->shouldReceive('get')
+            ->with('signed-requests.key')
+            ->andReturn('key');
+
+        $this->assertSame('key', $this->configuration->getSigningKey());
+    }
+}

--- a/tests/Middlewares/Guzzle/GenerateSignatureTest.php
+++ b/tests/Middlewares/Guzzle/GenerateSignatureTest.php
@@ -7,7 +7,6 @@ use Tests\TestCase;
 use GuzzleHttp\Psr7\Request;
 use Illuminate\Config\Repository;
 use Psr\Http\Message\RequestInterface;
-use SoapBox\SignedRequests\Requests\Generator;
 use SoapBox\SignedRequests\Configurations\Configuration;
 use SoapBox\SignedRequests\Middlewares\Guzzle\GenerateSignature;
 use SoapBox\SignedRequests\Configurations\RepositoryConfiguration;

--- a/tests/Middlewares/Guzzle/GenerateSignatureTest.php
+++ b/tests/Middlewares/Guzzle/GenerateSignatureTest.php
@@ -8,7 +8,9 @@ use GuzzleHttp\Psr7\Request;
 use Illuminate\Config\Repository;
 use Psr\Http\Message\RequestInterface;
 use SoapBox\SignedRequests\Requests\Generator;
+use SoapBox\SignedRequests\Configurations\Configuration;
 use SoapBox\SignedRequests\Middlewares\Guzzle\GenerateSignature;
+use SoapBox\SignedRequests\Configurations\RepositoryConfiguration;
 
 class GenerateSignatureTest extends TestCase
 {
@@ -17,7 +19,7 @@ class GenerateSignatureTest extends TestCase
      */
     public function it_can_be_constructed()
     {
-        $middleware = new GenerateSignature(new Generator(Mockery::mock(Repository::class)));
+        $middleware = new GenerateSignature(Mockery::mock(Configuration::class));
         $this->assertInstanceOf(GenerateSignature::class, $middleware);
     }
 
@@ -45,7 +47,7 @@ class GenerateSignatureTest extends TestCase
         $key = $configurations->shouldReceive('get')
             ->with('signed-requests.key')
             ->andReturn('bigsecretrighthereitellyouwhat');
-        $middleware = new GenerateSignature(new Generator($configurations));
+        $middleware = new GenerateSignature(new RepositoryConfiguration($configurations));
 
         $nextHandler = function (RequestInterface $request, array $options) {
             return $request;

--- a/tests/Middlewares/Laravel/VerifySignatureTest.php
+++ b/tests/Middlewares/Laravel/VerifySignatureTest.php
@@ -11,7 +11,6 @@ use Illuminate\Cache\ArrayStore;
 use SoapBox\SignedRequests\Signature;
 use SoapBox\SignedRequests\Requests\Signed;
 use SoapBox\SignedRequests\Requests\Payload;
-use SoapBox\SignedRequests\Requests\Generator;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Config\Repository as Configurations;
 use SoapBox\SignedRequests\Middlewares\Laravel\VerifySignature;

--- a/tests/Requests/GeneratorTest.php
+++ b/tests/Requests/GeneratorTest.php
@@ -6,13 +6,13 @@ use Mockery;
 use Tests\TestCase;
 use GuzzleHttp\Psr7\Request;
 use SoapBox\SignedRequests\Signature;
-use Illuminate\Contracts\Config\Repository;
 use SoapBox\SignedRequests\Requests\Payload;
 use SoapBox\SignedRequests\Requests\Generator;
+use SoapBox\SignedRequests\Configurations\Configuration;
 
 class GeneratorTest extends TestCase
 {
-    private $repository;
+    private $configuration;
     private $generator;
 
     /**
@@ -20,26 +20,22 @@ class GeneratorTest extends TestCase
      */
     public function setup_a_local_generator()
     {
-        $this->repository = Mockery::mock(Repository::class);
+        $this->configuration = Mockery::mock(Configuration::class);
 
-        $this->repository
-            ->shouldReceive('get')
-            ->with('signed-requests.headers.algorithm')
+        $this->configuration
+            ->shouldReceive('getAlgorithmHeader')
             ->andReturn('X-ALGORITHM');
-        $this->repository
-            ->shouldReceive('get')
-            ->with('signed-requests.headers.signature')
+        $this->configuration
+            ->shouldReceive('getSignatureHeader')
             ->andReturn('X-SIGNATURE');
-        $this->repository
-            ->shouldReceive('get')
-            ->with('signed-requests.algorithm')
+        $this->configuration
+            ->shouldReceive('getSigningAlgorithm')
             ->andReturn('sha256');
-        $this->repository
-            ->shouldReceive('get')
-            ->with('signed-requests.key')
+        $this->configuration
+            ->shouldReceive('getSigningKey')
             ->andReturn('key');
 
-        $this->generator = new Generator($this->repository);
+        $this->generator = new Generator($this->configuration);
     }
 
     /**

--- a/tests/Requests/VerifierTest.php
+++ b/tests/Requests/VerifierTest.php
@@ -4,7 +4,6 @@ namespace Tests\Requests;
 
 use Carbon\Carbon;
 use Tests\TestCase;
-use Ramsey\Uuid\Uuid;
 use Illuminate\Http\Request;
 use SoapBox\SignedRequests\Signature;
 use SoapBox\SignedRequests\Requests\Payload;


### PR DESCRIPTION
This change decouples the generator from the illuminate configuration repository by introducing an adapter layer. The major advantage this will provide is giving us the ability to have multiple custom signed requests within a single project.

This resolves half of the requested functionality in https://github.com/SoapBox/SignedRequests/issues/13.