### PR TITLE
[Change] Do not normalize URI

### DIFF
--- a/src/Requests/Payload.php
+++ b/src/Requests/Payload.php
@@ -72,7 +72,7 @@ class Payload
             'id' => (string) $id,
             'method' => $this->request->getMethod(),
             'timestamp' => $timestamp,
-            'uri' => (string) $this->request->url() . $query,
+            'uri' => (string) $this->request->url() . urldecode($query),
             'content' => $this->request->getContent()
         ], JSON_UNESCAPED_SLASHES);
     }

--- a/src/Requests/Payload.php
+++ b/src/Requests/Payload.php
@@ -71,7 +71,7 @@ class Payload
             'id' => (string) $id,
             'method' => $this->request->getMethod(),
             'timestamp' => $timestamp,
-            'uri' => (string) $this->request->fullUrl(),
+            'uri' => (string) $this->request->fullUrlWithQuery([]),
             'content' => $this->request->getContent()
         ], JSON_UNESCAPED_SLASHES);
     }

--- a/src/Requests/Payload.php
+++ b/src/Requests/Payload.php
@@ -66,12 +66,13 @@ class Payload
     {
         $id = $this->request->headers->get('X-SIGNED-ID', '');
         $timestamp = $this->request->headers->get('X-SIGNED-TIMESTAMP', '');
+        $query = !empty($this->request->query()) ? '?' . http_build_query($this->request->query()) : '';
 
         return json_encode([
             'id' => (string) $id,
             'method' => $this->request->getMethod(),
             'timestamp' => $timestamp,
-            'uri' => (string) $this->request->fullUrlWithQuery([]),
+            'uri' => (string) $this->request->url() . $query,
             'content' => $this->request->getContent()
         ], JSON_UNESCAPED_SLASHES);
     }


### PR DESCRIPTION
Update the `Payload::generateFromIlluminateRequest()` to manually concat the url and query params as `fullUrl()` normalized the query params causing the signature to be invalid