### PR TITLE
[Change] Stop Escaping Unicode Characters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "ramsey/uuid": "^3.6"
     },
     "require-dev": {
+        "jshayes/fake-requests": "^2.0",
         "mockery/mockery": "^0.9.9",
         "orchestra/testbench": "^3.4",
         "phpunit/phpunit": "^6.0",

--- a/src/Requests/Payload.php
+++ b/src/Requests/Payload.php
@@ -44,28 +44,27 @@ class Payload
         $timestamp = isset($this->request->getHeader('X-SIGNED-TIMESTAMP')[0]) ?
             $this->request->getHeader('X-SIGNED-TIMESTAMP')[0] : '';
 
-        $string = json_decode((string) $this->request->getBody());
-
-        if (is_null($string)) {
-            return json_encode([
-                'id' => (string)$id,
-                'method' => strtoupper($this->request->getMethod()),
-                'timestamp' => $timestamp,
-                'uri' => rtrim((string)$this->request->getUri(), '/'),
-                'content' => (string) $this->request->getBody()
-            ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
-        }
-
-        return json_encode([
+        $payload = [
             'id' => (string) $id,
             'method' => strtoupper($this->request->getMethod()),
             'timestamp' => $timestamp,
-            'uri' => rtrim((string) $this->request->getUri(), '/'),
-            'content' => json_encode(
-                json_decode((string) $this->request->getBody()),
-                JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
-            )
-        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+            'uri' => rtrim((string) $this->request->getUri(), '/')
+        ];
+
+        if (is_null(json_decode((string) $this->request->getBody()))) {
+            $payload = array_merge($payload, [
+                'content' => (string) $this->request->getBody()
+            ]);
+        } else {
+            $payload = array_merge($payload, [
+                'content' => json_encode(
+                    json_decode((string) $this->request->getBody()),
+                    JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+                )
+            ]);
+        }
+
+        return json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 
     /**
@@ -82,28 +81,27 @@ class Payload
         $id = $this->request->headers->get('X-SIGNED-ID', '');
         $timestamp = $this->request->headers->get('X-SIGNED-TIMESTAMP', '');
 
-        $string = json_decode((string) $this->request->getContent());
-
-        if (is_null($string)) {
-            return json_encode([
-                'id' => (string) $id,
-                'method' => strtoupper($this->request->getMethod()),
-                'timestamp' => $timestamp,
-                'uri' => rtrim((string) $this->request->fullUrl(), '/'),
-                'content' => (string) $this->request->getContent()
-            ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
-        }
-
-        return json_encode([
-            'id' => (string)$id,
+        $payload = [
+            'id' => (string) $id,
             'method' => strtoupper($this->request->getMethod()),
             'timestamp' => $timestamp,
             'uri' => rtrim((string) $this->request->fullUrl(), '/'),
-            'content' => json_encode(
-                json_decode((string) $this->request->getContent()),
-                JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
-            )
-        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        ];
+
+        if (is_null(json_decode((string) $this->request->getContent()))) {
+            $payload = array_merge($payload, [
+                'content' => (string) $this->request->getContent()
+            ]);
+        } else {
+            $payload = array_merge($payload, [
+                'content' => json_encode(
+                    json_decode((string)$this->request->getContent()),
+                    JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+                )
+            ]);
+        }
+
+        return json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 
     /**

--- a/src/Requests/Payload.php
+++ b/src/Requests/Payload.php
@@ -82,13 +82,28 @@ class Payload
         $id = $this->request->headers->get('X-SIGNED-ID', '');
         $timestamp = $this->request->headers->get('X-SIGNED-TIMESTAMP', '');
 
+        $string = json_decode((string) $this->request->getContent());
+
+        if (is_null($string)) {
+            return json_encode([
+                'id' => (string) $id,
+                'method' => strtoupper($this->request->getMethod()),
+                'timestamp' => $timestamp,
+                'uri' => rtrim((string) $this->request->fullUrl(), '/'),
+                'content' => (string) $this->request->getContent()
+            ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        }
+
         return json_encode([
-            'id' => (string) $id,
+            'id' => (string)$id,
             'method' => strtoupper($this->request->getMethod()),
             'timestamp' => $timestamp,
-            'uri' => (string) $this->request->fullUrl(),
-            'content' => $this->request->getContent()
-        ], JSON_UNESCAPED_SLASHES);
+            'uri' => rtrim((string) $this->request->fullUrl(), '/'),
+            'content' => json_encode(
+                json_decode((string) $this->request->getContent()),
+                JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+            )
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 
     /**

--- a/src/Requests/Payload.php
+++ b/src/Requests/Payload.php
@@ -44,12 +44,27 @@ class Payload
         $timestamp = isset($this->request->getHeader('X-SIGNED-TIMESTAMP')[0]) ?
             $this->request->getHeader('X-SIGNED-TIMESTAMP')[0] : '';
 
+        $string = json_decode((string) $this->request->getBody());
+
+        if (is_null($string)) {
+            return json_encode([
+                'id' => (string)$id,
+                'method' => strtoupper($this->request->getMethod()),
+                'timestamp' => $timestamp,
+                'uri' => rtrim((string)$this->request->getUri(), '/'),
+                'content' => (string) $this->request->getBody()
+            ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        }
+
         return json_encode([
             'id' => (string) $id,
             'method' => strtoupper($this->request->getMethod()),
             'timestamp' => $timestamp,
-            'uri' => (string) $this->request->getUri(),
-            'content' => $this->request->getBody()->getContents()
+            'uri' => rtrim((string) $this->request->getUri(), '/'),
+            'content' => json_encode(
+                json_decode((string) $this->request->getBody()),
+                JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+            )
         ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 

--- a/src/Requests/Payload.php
+++ b/src/Requests/Payload.php
@@ -50,7 +50,7 @@ class Payload
             'timestamp' => $timestamp,
             'uri' => (string) $this->request->getUri(),
             'content' => $this->request->getBody()->getContents()
-        ], JSON_UNESCAPED_SLASHES);
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 
     /**

--- a/src/Requests/Payload.php
+++ b/src/Requests/Payload.php
@@ -46,7 +46,7 @@ class Payload
 
         return json_encode([
             'id' => (string) $id,
-            'method' => $this->request->getMethod(),
+            'method' => strtoupper($this->request->getMethod()),
             'timestamp' => $timestamp,
             'uri' => (string) $this->request->getUri(),
             'content' => $this->request->getBody()->getContents()
@@ -69,7 +69,7 @@ class Payload
 
         return json_encode([
             'id' => (string) $id,
-            'method' => $this->request->getMethod(),
+            'method' => strtoupper($this->request->getMethod()),
             'timestamp' => $timestamp,
             'uri' => (string) $this->request->fullUrl(),
             'content' => $this->request->getContent()

--- a/src/Requests/Verifier.php
+++ b/src/Requests/Verifier.php
@@ -142,7 +142,7 @@ class Verifier
         json_decode($content);
 
         if (json_last_error() == JSON_ERROR_NONE) {
-            return json_encode(json_decode($content), JSON_UNESCAPED_SLASHES);
+            return json_encode(json_decode($content), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
         }
 
         return $content;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Tests;
+
+use Carbon\Carbon;
+use Ramsey\Uuid\Uuid;
+use JSHayes\FakeRequests\MockHandler;
+use Ramsey\Uuid\UuidFactoryInterface;
+use JSHayes\FakeRequests\ClientFactory;
+use SoapBox\SignedRequests\Configurations\CustomConfiguration;
+use SoapBox\SignedRequests\Middlewares\Guzzle\GenerateSignature;
+
+class ClientTest extends TestCase
+{
+    private function expectUuid4(string $uuid): void
+    {
+        Uuid::setFactory(new class($uuid) implements UuidFactoryInterface {
+            public function __construct(string $uuid)
+            {
+                $this->uuid = $uuid;
+            }
+
+            public function uuid1($node = null, $clockSeq = null)
+            {
+                return null;
+            }
+
+            public function uuid3($ns, $name)
+            {
+                return null;
+            }
+
+            public function uuid4()
+            {
+                return $this->uuid;
+            }
+
+            public function uuid5($ns, $name)
+            {
+                return null;
+            }
+
+            public function fromBytes($bytes)
+            {
+                return null;
+            }
+
+            public function fromString($uuid)
+            {
+                return null;
+            }
+
+            public function fromInteger($integer)
+            {
+                return null;
+            }
+        });
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $factory = new ClientFactory();
+        $factory->setHandler($this->handler = new MockHandler());
+
+        $algorithmHeader = 'Algorithm';
+        $signatureHeader = 'Signature';
+        $signingAlgorithm = 'sha256';
+        $signingKey = 'key';
+
+        $config = new CustomConfiguration(
+            $algorithmHeader,
+            $signatureHeader,
+            $signingAlgorithm,
+            $signingKey
+        );
+
+        $middleware = new GenerateSignature($config);
+
+        $this->client = $factory->make();
+        $this->client->getConfig('handler')->push($middleware);
+    }
+
+    /**
+     * @test
+     */
+    public function it_generates_a_signature_with_a_simple_json_payload()
+    {
+        Carbon::setTestNow('2001-01-01 00:00:00');
+        $this->expectUuid4('303103f5-3dca-4704-96ad-860717769ec9');
+
+        $uri = 'https://localhost';
+
+        $this->handler->expects('POST', $uri)
+            ->inspectRequest(function ($request) use ($uri) {
+                $this->assertTrue($request->hasHeader('Algorithm'));
+                $this->assertTrue($request->hasHeader('Signature'));
+                $this->assertSame(
+                    'b9f912a4fc4b2952a48380579d3e4a1c55c0537ce583b3da7cc9f6c67fe4caa7',
+                    $request->getHeader('Signature')[0]
+                );
+            });
+
+        $this->client->post($uri, ['json' => ['test' => 'test']]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_generates_a_signature_with_a_simple_json_payload_containing_ã()
+    {
+        Carbon::setTestNow('2001-01-01 00:00:00');
+        $this->expectUuid4('303103f5-3dca-4704-96ad-860717769ec9');
+
+        $uri = 'https://localhost';
+
+        $this->handler->expects('POST', $uri)
+            ->inspectRequest(function ($request) use ($uri) {
+                $this->assertTrue($request->hasHeader('Algorithm'));
+                $this->assertTrue($request->hasHeader('Signature'));
+                $this->assertSame(
+                    'bf0f2eb48acf86cf72a87b48393f71fb2eebbb2c11fa0d838cbb127d74a0a00e',
+                    $request->getHeader('Signature')[0]
+                );
+            });
+
+        $this->client->post($uri, ['json' => ['test' => 'ã']]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_generates_a_signature_with_a_simple_json_payload_containing_好()
+    {
+        Carbon::setTestNow('2001-01-01 00:00:00');
+        $this->expectUuid4('303103f5-3dca-4704-96ad-860717769ec9');
+
+        $uri = 'https://localhost';
+
+        $this->handler->expects('POST', $uri)
+            ->inspectRequest(function ($request) use ($uri) {
+                $this->assertTrue($request->hasHeader('Algorithm'));
+                $this->assertTrue($request->hasHeader('Signature'));
+                $this->assertSame(
+                    '10b165e59775d1a564be49046edd60137d40fcecebbdf59f41b01568ca07db63',
+                    $request->getHeader('Signature')[0]
+                );
+            });
+
+        $this->client->post($uri, ['json' => ['test' => '好']]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_generates_a_signature_with_a_simple_json_payload_containing_a_uri()
+    {
+        Carbon::setTestNow('2001-01-01 00:00:00');
+        $this->expectUuid4('303103f5-3dca-4704-96ad-860717769ec9');
+
+        $uri = 'https://localhost';
+
+        $this->handler->expects('POST', $uri)
+            ->inspectRequest(function ($request) use ($uri) {
+                $this->assertTrue($request->hasHeader('Algorithm'));
+                $this->assertTrue($request->hasHeader('Signature'));
+                $this->assertSame(
+                    '8c36d7384111d27336c410ebfec38c7da2eca9ec4779216f9cb8f921a08c4572',
+                    $request->getHeader('Signature')[0]
+                );
+            });
+
+        $this->client->post($uri, ['json' => ['test' => $uri]]);
+    }
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -120,7 +120,7 @@ class ClientTest extends TestCase
                 $this->assertTrue($request->hasHeader('Algorithm'));
                 $this->assertTrue($request->hasHeader('Signature'));
                 $this->assertSame(
-                    'bf0f2eb48acf86cf72a87b48393f71fb2eebbb2c11fa0d838cbb127d74a0a00e',
+                    'd35d92484222fce7e5c194381e5f53342caae6fa626cd61e3431bddc549b34e1',
                     $request->getHeader('Signature')[0]
                 );
             });
@@ -143,7 +143,7 @@ class ClientTest extends TestCase
                 $this->assertTrue($request->hasHeader('Algorithm'));
                 $this->assertTrue($request->hasHeader('Signature'));
                 $this->assertSame(
-                    '10b165e59775d1a564be49046edd60137d40fcecebbdf59f41b01568ca07db63',
+                    '65ff94dce4894eb306a76ff0d397ec264b1c4980b57afbc3dd9526af242d239b',
                     $request->getHeader('Signature')[0]
                 );
             });
@@ -166,11 +166,79 @@ class ClientTest extends TestCase
                 $this->assertTrue($request->hasHeader('Algorithm'));
                 $this->assertTrue($request->hasHeader('Signature'));
                 $this->assertSame(
-                    '8c36d7384111d27336c410ebfec38c7da2eca9ec4779216f9cb8f921a08c4572',
+                    'ebd68bfe7ed51c050fb92db098946cd21b7b23be6f682360a5e893840a1dc52f',
                     $request->getHeader('Signature')[0]
                 );
             });
 
         $this->client->post($uri, ['json' => ['test' => $uri]]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_generates_a_signature_with_a_complex_json_payload()
+    {
+        Carbon::setTestNow('2001-01-01 00:00:00');
+        $this->expectUuid4('303103f5-3dca-4704-96ad-860717769ec9');
+
+        $uri = 'https://localhost/poop';
+
+        $this->handler->expects('POST', $uri)
+            ->inspectRequest(function ($request) use ($uri) {
+                $this->assertTrue($request->hasHeader('Algorithm'));
+                $this->assertTrue($request->hasHeader('Signature'));
+                $this->assertSame(
+                    '0c3f0c81ba1fa3df9d3e0a1d72c4d491125153c0dea8355b6d48fe7ef1a4dacc',
+                    $request->getHeader('Signature')[0]
+                );
+            });
+
+        $this->client->post(
+            $uri,
+            [
+                'json' => [
+                    'users' => [
+                        ['id' => 1, 'name' => 'Chris Hayes', 'email' => 'hayes@soapboxhq.com'],
+                        ['id' => 2, 'name' => 'Jaspaul Bola', 'email' => 'jaspaul@soapboxhq.com'],
+                        ['id' => 3, 'name' => 'Mr Penã 💩', 'email' => 'Mr-Penã@soapboxhq.com']
+                    ]
+                ]
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_generates_a_signature_with_a_complex_json_payload_after_stripping_the_trailing_slash()
+    {
+        Carbon::setTestNow('2001-01-01 00:00:00');
+        $this->expectUuid4('303103f5-3dca-4704-96ad-860717769ec9');
+
+        $uri = 'https://localhost/poop/';
+
+        $this->handler->expects('POST', $uri)
+            ->inspectRequest(function ($request) use ($uri) {
+                $this->assertTrue($request->hasHeader('Algorithm'));
+                $this->assertTrue($request->hasHeader('Signature'));
+                $this->assertSame(
+                    '0c3f0c81ba1fa3df9d3e0a1d72c4d491125153c0dea8355b6d48fe7ef1a4dacc',
+                    $request->getHeader('Signature')[0]
+                );
+            });
+
+        $this->client->post(
+            $uri,
+            [
+                'json' => [
+                    'users' => [
+                        ['id' => 1, 'name' => 'Chris Hayes', 'email' => 'hayes@soapboxhq.com'],
+                        ['id' => 2, 'name' => 'Jaspaul Bola', 'email' => 'jaspaul@soapboxhq.com'],
+                        ['id' => 3, 'name' => 'Mr Penã 💩', 'email' => 'Mr-Penã@soapboxhq.com']
+                    ]
+                ]
+            ]
+        );
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -241,4 +241,50 @@ class ClientTest extends TestCase
             ]
         );
     }
+
+    /**
+     * @test
+     */
+    public function it_generates_a_signature_with_a_simple_json_get_payload()
+    {
+        Carbon::setTestNow('2001-01-01 00:00:00');
+        $this->expectUuid4('303103f5-3dca-4704-96ad-860717769ec9');
+
+        $uri = 'https://localhost';
+
+        $this->handler->expects('GET', $uri)
+            ->inspectRequest(function ($request) use ($uri) {
+                $this->assertTrue($request->hasHeader('Algorithm'));
+                $this->assertTrue($request->hasHeader('Signature'));
+                $this->assertSame(
+                    '939ada016b60aa267980a73f62e6dc583b03b35a2abf0dea5b054871d6c6a306',
+                    $request->getHeader('Signature')[0]
+                );
+            });
+
+        $this->client->get($uri, ['json' => ['payload' => 'payload']]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_generates_a_signature_with_a_simple_get_payload()
+    {
+        Carbon::setTestNow('2001-01-01 00:00:00');
+        $this->expectUuid4('303103f5-3dca-4704-96ad-860717769ec9');
+
+        $uri = 'https://localhost';
+
+        $this->handler->expects('GET', $uri)
+            ->inspectRequest(function ($request) use ($uri) {
+                $this->assertTrue($request->hasHeader('Algorithm'));
+                $this->assertTrue($request->hasHeader('Signature'));
+                $this->assertSame(
+                    '9feb58dfece796627b16f7865fc19ee6bfc5b231d49b12d83170d74d22bf9641',
+                    $request->getHeader('Signature')[0]
+                );
+            });
+
+        $this->client->get($uri, ['body' => 'payload']);
+    }
 }

--- a/tests/Requests/PayloadTest.php
+++ b/tests/Requests/PayloadTest.php
@@ -106,6 +106,72 @@ class PayloadTest extends TestCase
     /**
      * @test
      */
+    public function it_upper_cases_the_illuminate_request_method()
+    {
+        $now = (string)Carbon::now();
+        $id = (string)Uuid::uuid4();
+
+        $uri = 'https://localhost';
+        $method = 'get';
+        $parameters = [];
+        $cookies = [];
+        $files = [];
+        $server = [
+            'HTTP_X-SIGNED-ID' => $id,
+            'HTTP_X-SIGNED-TIMESTAMP' => $now
+        ];
+        $content = null;
+
+        $request = IlluminateRequest::create(
+            $uri,
+            $method,
+            $parameters,
+            $cookies,
+            $files,
+            $server,
+            $content
+        );
+
+        $expected = json_encode([
+            'id' => $id,
+            'method' => 'GET',
+            'timestamp' => $now,
+            'uri' => $uri,
+            'content' => $request->getContent()
+        ], JSON_UNESCAPED_SLASHES);
+
+        $this->assertEquals($expected, (string)new Payload($request));
+    }
+
+
+    /**
+     * @test
+     */
+    public function it_upper_cases_the_guzzle_request_method()
+    {
+        $now = (string)Carbon::now();
+
+        $uri = 'https://localhost';
+        $id = Uuid::uuid4();
+
+        $request = (new GuzzleRequest('get', 'https://localhost', [], 'content'))
+            ->withHeader('X-SIGNED-ID', $id)
+            ->withHeader('X-SIGNED-TIMESTAMP', $now);
+
+        $expected = json_encode([
+            'id' => $id,
+            'method' => 'GET',
+            'timestamp' => $now,
+            'uri' => $uri,
+            'content' => 'content'
+        ], JSON_UNESCAPED_SLASHES);
+
+        $this->assertEquals($expected, (string)new Payload($request));
+    }
+
+    /**
+     * @test
+     */
     public function it_translates_non_requests_to_an_empty_string()
     {
         $this->assertEquals('', (string) new Payload(null));

--- a/tests/Requests/PayloadTest.php
+++ b/tests/Requests/PayloadTest.php
@@ -284,7 +284,7 @@ class PayloadTest extends TestCase
             ->withHeader('X-SIGNED-ID', '303103f5-3dca-4704-96ad-860717769ec9')
             ->withHeader('X-SIGNED-TIMESTAMP', '2018-04-06 20:34:47');
 
-        $expected = '{"id":"303103f5-3dca-4704-96ad-860717769ec9","method":"GET","timestamp":"2018-04-06 20:34:47","uri":"https://localhost","content":"{\"url\":\"https:\\\\/\\\\/google.com\"}"}';
+        $expected = '{"id":"303103f5-3dca-4704-96ad-860717769ec9","method":"GET","timestamp":"2018-04-06 20:34:47","uri":"https://localhost","content":"{\"url\":\"https://google.com\"}"}';
 
         $this->assertEquals($expected, (string) new Payload($request));
     }

--- a/tests/Requests/PayloadTest.php
+++ b/tests/Requests/PayloadTest.php
@@ -110,4 +110,116 @@ class PayloadTest extends TestCase
     {
         $this->assertEquals('', (string) new Payload(null));
     }
+
+    /**
+     * @test
+     */
+    public function it_stringifies_a_simple_payload_to_a_string()
+    {
+        $request = (new GuzzleRequest('GET', 'https://localhost', [], 'content'))
+            ->withHeader('X-SIGNED-ID', '303103f5-3dca-4704-96ad-860717769ec9')
+            ->withHeader('X-SIGNED-TIMESTAMP', '2018-04-06 20:34:47');
+
+        $expected = '{"id":"303103f5-3dca-4704-96ad-860717769ec9","method":"GET","timestamp":"2018-04-06 20:34:47","uri":"https://localhost","content":"content"}';
+
+        $this->assertEquals($expected, (string) new Payload($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_stringifies_a_payload_with_an_embedded_url_to_a_string()
+    {
+        $request = (new GuzzleRequest('GET', 'https://localhost', [], 'https://google.com'))
+            ->withHeader('X-SIGNED-ID', '303103f5-3dca-4704-96ad-860717769ec9')
+            ->withHeader('X-SIGNED-TIMESTAMP', '2018-04-06 20:34:47');
+
+        $expected = '{"id":"303103f5-3dca-4704-96ad-860717769ec9","method":"GET","timestamp":"2018-04-06 20:34:47","uri":"https://localhost","content":"https://google.com"}';
+
+        $this->assertEquals($expected, (string) new Payload($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_stringifies_a_payload_with_the_ã_character_to_use_the_escaped_string()
+    {
+        $request = (new GuzzleRequest('GET', 'https://localhost', [], 'ã'))
+            ->withHeader('X-SIGNED-ID', '303103f5-3dca-4704-96ad-860717769ec9')
+            ->withHeader('X-SIGNED-TIMESTAMP', '2018-04-06 20:34:47');
+
+        $expected = '{"id":"303103f5-3dca-4704-96ad-860717769ec9","method":"GET","timestamp":"2018-04-06 20:34:47","uri":"https://localhost","content":"ã"}';
+
+        $this->assertEquals($expected, (string) new Payload($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_stringifies_a_payload_with_the_好_character_to_use_the_escaped_string()
+    {
+        $request = (new GuzzleRequest('GET', 'https://localhost', [], '好'))
+            ->withHeader('X-SIGNED-ID', '303103f5-3dca-4704-96ad-860717769ec9')
+            ->withHeader('X-SIGNED-TIMESTAMP', '2018-04-06 20:34:47');
+
+        $expected = '{"id":"303103f5-3dca-4704-96ad-860717769ec9","method":"GET","timestamp":"2018-04-06 20:34:47","uri":"https://localhost","content":"好"}';
+
+        $this->assertEquals($expected, (string) new Payload($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_stringifies_a_json_payload_to_a_string()
+    {
+        $request = (new GuzzleRequest('GET', 'https://localhost', [], json_encode(['test' => 'test'])))
+            ->withHeader('X-SIGNED-ID', '303103f5-3dca-4704-96ad-860717769ec9')
+            ->withHeader('X-SIGNED-TIMESTAMP', '2018-04-06 20:34:47');
+
+        $expected = '{"id":"303103f5-3dca-4704-96ad-860717769ec9","method":"GET","timestamp":"2018-04-06 20:34:47","uri":"https://localhost","content":"{\"test\":\"test\"}"}';
+
+        $this->assertEquals($expected, (string) new Payload($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_stringifies_a_json_payload_with_the_ã_character_to_a_string()
+    {
+        $request = (new GuzzleRequest('GET', 'https://localhost', [], json_encode(['ã' => 'ã'], JSON_UNESCAPED_UNICODE)))
+            ->withHeader('X-SIGNED-ID', '303103f5-3dca-4704-96ad-860717769ec9')
+            ->withHeader('X-SIGNED-TIMESTAMP', '2018-04-06 20:34:47');
+
+        $expected = '{"id":"303103f5-3dca-4704-96ad-860717769ec9","method":"GET","timestamp":"2018-04-06 20:34:47","uri":"https://localhost","content":"{\"ã\":\"ã\"}"}';
+
+        $this->assertEquals($expected, (string) new Payload($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_stringifies_a_json_payload_with_the_好_character_to_a_string()
+    {
+        $request = (new GuzzleRequest('GET', 'https://localhost', [], json_encode(['好' => '好'], JSON_UNESCAPED_UNICODE)))
+            ->withHeader('X-SIGNED-ID', '303103f5-3dca-4704-96ad-860717769ec9')
+            ->withHeader('X-SIGNED-TIMESTAMP', '2018-04-06 20:34:47');
+
+        $expected = '{"id":"303103f5-3dca-4704-96ad-860717769ec9","method":"GET","timestamp":"2018-04-06 20:34:47","uri":"https://localhost","content":"{\"好\":\"好\"}"}';
+
+        $this->assertEquals($expected, (string) new Payload($request));
+    }
+
+    /**
+     * @test
+     */
+    public function it_stringifies_a_json_payload_with_a_url_to_a_string()
+    {
+        $request = (new GuzzleRequest('GET', 'https://localhost', [], json_encode(['url' => 'https://google.com'], JSON_UNESCAPED_UNICODE)))
+            ->withHeader('X-SIGNED-ID', '303103f5-3dca-4704-96ad-860717769ec9')
+            ->withHeader('X-SIGNED-TIMESTAMP', '2018-04-06 20:34:47');
+
+        $expected = '{"id":"303103f5-3dca-4704-96ad-860717769ec9","method":"GET","timestamp":"2018-04-06 20:34:47","uri":"https://localhost","content":"{\"url\":\"https:\\\\/\\\\/google.com\"}"}';
+
+        $this->assertEquals($expected, (string) new Payload($request));
+    }
 }


### PR DESCRIPTION
This changes how we handle encoding the request into json. We will no longer escape unicode characters that are provided via the request. Previously characters like `ã` would be encoded to `\u00e3` if they were provided to the Payload class, they no longer will be. Instead the `ã` will be preserved as `ã` for the signature. See the tests for more details.