### PR TITLE
[Change] Introduces Request Timestamp Validation

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SoapBox\SignedRequests;
+
+use DateTime;
+
+class Helpers
+{
+    /**
+     * Verifies if the provided date string is in the given format
+     *
+     * @param string $datetime
+     * @param string $format
+     *
+     * @return boolean
+     */
+    public static function verifyDateTime(string $datetime, string $format): bool
+    {
+        $formatted = DateTime::createFromFormat($format, $datetime);
+
+        $errors = DateTime::getLastErrors();
+
+        if (!empty($errors['warning_count'])) {
+            return false;
+        }
+
+        return $formatted !== false;
+    }
+}

--- a/src/Requests/Generator.php
+++ b/src/Requests/Generator.php
@@ -47,7 +47,10 @@ class Generator
         $key = $this->configuration->getSigningKey();
 
         $request = $request->withHeader('X-SIGNED-ID', (string) Uuid::uuid4());
-        $request = $request->withHeader('X-SIGNED-TIMESTAMP', (string) Carbon::now());
+        $request = $request->withHeader(
+            'X-SIGNED-TIMESTAMP',
+            Carbon::now()->format('Y-m-d H:i:s')
+        );
 
         $signature = new Signature(new Payload($request), $algorithm, $key);
 

--- a/src/Requests/Verifier.php
+++ b/src/Requests/Verifier.php
@@ -4,6 +4,7 @@ namespace SoapBox\SignedRequests\Requests;
 
 use Carbon\Carbon;
 use Illuminate\Http\Request;
+use SoapBox\SignedRequests\Helpers;
 use SoapBox\SignedRequests\Signature;
 
 class Verifier
@@ -185,10 +186,12 @@ class Verifier
      */
     public function isExpired(int $tolerance) : bool
     {
-        $issuedAt =
-            Carbon::parse($this->headers->get('X-SIGNED-TIMESTAMP', '1901-01-01 12:00:00'));
+        $timestamp = $this->headers->get('X-SIGNED-TIMESTAMP', '1901-01-01 12:00:00');
+        $issuedAt = Carbon::parse($timestamp);
 
-        return Carbon::now()->diffInSeconds($issuedAt) > $tolerance;
+        $isValid = Helpers::verifyDateTime($timestamp, 'Y-m-d H:i:s');
+
+        return !$isValid || Carbon::now()->diffInSeconds($issuedAt) > $tolerance;
     }
 
     /**

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests;
+
+use Carbon\Carbon;
+use SoapBox\SignedRequests\Helpers;
+use SoapBox\SignedRequests\Signature;
+
+class HelpersTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_correctly_verifies_that_the_provided_datetime_string_is_in_the_given_format()
+    {
+        $datetime = Carbon::parse('2001-01-31 12:11:18');
+
+        $this->assertTrue(Helpers::verifyDateTime((string) $datetime, 'Y-m-d H:i:s'));
+        $this->assertTrue(Helpers::verifyDateTime($datetime->format('Y-m-d H:i:s'), 'Y-m-d H:i:s'));
+        $this->assertTrue(Helpers::verifyDateTime($datetime->format('Y-m-d H:i:s.u'), 'Y-m-d H:i:s.u'));
+        $this->assertTrue(Helpers::verifyDateTime($datetime->format('Y-m-d'), 'Y-m-d'));
+        $this->assertTrue(Helpers::verifyDateTime($datetime->format('Y-d-m H:i:s'), 'Y-d-m H:i:s'));
+
+        $this->assertFalse(Helpers::verifyDateTime($datetime->format('Y-m-d H:i:s.u'), 'Y-m-d H:i:s'));
+        $this->assertFalse(Helpers::verifyDateTime($datetime->format('Y-m-d H-i-s'), 'Y-m-d H:i:s.u'));
+        $this->assertFalse(Helpers::verifyDateTime($datetime->format('Y-m-d H:i:s'), 'Y-d-m H:i:s'));
+        $this->assertFalse(Helpers::verifyDateTime($datetime->format('Y-m-d H:i:s'), 'Y-m-d'));
+        $this->assertFalse(Helpers::verifyDateTime($datetime->format('Y-m-d H:i:s'), 'Y-m-d-H:i:s.u'));
+    }
+}

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -4,7 +4,6 @@ namespace Tests;
 
 use Carbon\Carbon;
 use SoapBox\SignedRequests\Helpers;
-use SoapBox\SignedRequests\Signature;
 
 class HelpersTest extends TestCase
 {

--- a/tests/Middlewares/Laravel/VerifySignatureTest.php
+++ b/tests/Middlewares/Laravel/VerifySignatureTest.php
@@ -86,7 +86,8 @@ class VerifySignatureTest extends TestCase
 
         $request = new Request();
 
-        $this->middleware->handle($request, function () { });
+        $this->middleware->handle($request, function () {
+        });
     }
 
     /**
@@ -169,7 +170,8 @@ class VerifySignatureTest extends TestCase
         $request = new Request($query, $request, $attributes, $cookies, $files, $server, 'a');
         $request->headers->set('signature', (string) new Signature(new Payload($request), 'sha256', 'key'));
 
-        $this->middleware->handle($request, function () { });
+        $this->middleware->handle($request, function () {
+        });
     }
 
     /**
@@ -257,7 +259,8 @@ class VerifySignatureTest extends TestCase
         $request = new Request($query, $request, $attributes, $cookies, $files, $server, 'a');
         $request->headers->set('signature', (string) new Signature(new Payload($request), 'sha256', 'key'));
 
-        $this->middleware->handle($request, function () { });
+        $this->middleware->handle($request, function () {
+        });
     }
 
     /**
@@ -303,6 +306,49 @@ class VerifySignatureTest extends TestCase
             $this->assertTrue(true);
         });
 
-        $this->middleware->handle($request, function () { });
+        $this->middleware->handle($request, function () {
+        });
+    }
+
+    /**
+     * @test
+     * @expectedException \SoapBox\SignedRequests\Exceptions\ExpiredRequestException
+     */
+    public function it_throws_an_expired_request_exception_if_the_timestamp_on_the_request_does_not_have_the_correct_format()
+    {
+        $id = (string) Uuid::uuid4();
+
+        $this->configurations->shouldReceive('get')
+            ->with('signed-requests.headers.signature')
+            ->andReturn('signature');
+
+        $this->configurations->shouldReceive('get')
+            ->with('signed-requests.headers.algorithm')
+            ->andReturn('algorithm');
+
+        $this->configurations->shouldReceive('get')
+            ->with('signed-requests.key')
+            ->andReturn('key');
+
+        $this->configurations->shouldReceive('get')
+            ->with('signed-requests.request-replay.allow')
+            ->andReturn(false);
+
+        $query = [];
+        $request = [];
+        $attributes = [];
+        $cookies = [];
+        $files = [];
+        $server = [
+            'HTTP_X-SIGNED-ID' => $id,
+            'HTTP_X-SIGNED-TIMESTAMP' => Carbon::now()->addSeconds(10)->format('Y-m-d'),
+            'HTTP_ALGORITHM' => 'sha256'
+        ];
+
+        $request = new Request($query, $request, $attributes, $cookies, $files, $server, 'a');
+        $request->headers->set('signature', (string) new Signature(new Payload($request), 'sha256', 'key'));
+
+        $this->middleware->handle($request, function () {
+        });
     }
 }


### PR DESCRIPTION
We now ensure that the timestamp on the request is both produced and consumed with the `Y-m-d H:i:s` format. Since we are introducing a new JS library to sign and verify requests it felt like a good time to agree on a format.