### PR TITLE
[Change] Key prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 .php_cs.cache
 coverage
 .DS_Store
+.idea

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,51 @@ Route::get('/fire', function () {
 })->middleware('verify-signature');
 ```
 
+### Setting Up Additional Keys
+
+You can also set up additional keys to use if you want different keys for different endpoints.
+
+Add them to your environment:
+
+```sh
+CUSTOM_SIGNED_REQUEST_ALGORITHM=
+CUSTOM_SIGNED_REQUEST_CACHE_PREFIX=
+CUSTOM_SIGNED_REQUEST_SIGNATURE_HEADER=
+CUSTOM_SIGNED_REQUEST_ALGORITHM_HEADER=
+CUSTOM_SIGNED_REQUEST_KEY=
+CUSTOM_SIGNED_REQUEST_ALLOW_REPLAYS=
+CUSTOM_SIGNED_REQUEST_TOLERANCE_SECONDS=
+```
+
+Update the configuration in `signed-requests.php`
+
+```php
+    'default' => [
+        ...
+    ],
+    'custom' => [
+        'algorithm' => env('CUSTOM_SIGNED_REQUEST_ALGORITHM', 'sha256'),
+        'cache-prefix' => env('CUSTOM_SIGNED_REQUEST_CACHE_PREFIX', 'signed-requests'),
+        'headers' => [
+            'signature' => env('CUSTOM_SIGNED_REQUEST_SIGNATURE_HEADER', 'X-Signature'),
+            'algorithm' => env('CUSTOM_SIGNED_REQUEST_ALGORITHM_HEADER', 'X-Signature-Algorithm')
+        ],
+        'key' => env('CUSTOM_SIGNED_REQUEST_KEY', 'key'),
+        'request-replay' => [
+            'allow' => env('CUSTOM_SIGNED_REQUEST_ALLOW_REPLAYS', false),
+            'tolerance' => env('CUSTOM_SIGNED_REQUEST_TOLERANCE_SECONDS', 30)
+        ]
+    ]
+```
+
+Set up your route to use the custom key. The param you pass must be the same name as the key you set in the configuration in `signed-requests.php`
+
+```php
+Route::get('/fire', function () {
+    return "You'll only see this if the signature of the request is valid!";
+})->middleware('verify-signature:custom');
+```
+
 ### Signing Postman Requests
 
 If you, like us, like to use [postman](https://www.getpostman.com/) to share your api internally you can use the following pre-request script to automatically sign your postman requests:

--- a/readme.md
+++ b/readme.md
@@ -87,8 +87,15 @@ function guid() {
     s4() + '-' + s4() + s4() + s4();
 }
 
+function getTimestamp() {
+    var date = (new Date()).toISOString();
+    date = date.split("T");
+    date[1] = date[1].split(".")[0];
+    return date.join(' ');
+}
+
 postman.setEnvironmentVariable("x-signed-id", guid());
-postman.setEnvironmentVariable("x-signed-timestamp", (new Date()).toUTCString());
+postman.setEnvironmentVariable("x-signed-timestamp", getTimestamp());
 postman.setEnvironmentVariable("x-algorithm", "sha256");
 
 var payload = {
@@ -96,13 +103,14 @@ var payload = {
     "method": request.method,
     "timestamp": postman.getEnvironmentVariable("x-signed-timestamp"),
     "uri": request.url.replace("{{url}}", postman.getEnvironmentVariable("url")),
-    "content": (Object.keys(request.data).length === 0) ? "" : request.data
+    "content": (Object.keys(request.data).length === 0) ? "" : JSON.stringify(JSON.parse(request.data))
 };
 
 var hash = CryptoJS.HmacSHA256(JSON.stringify(payload), postman.getEnvironmentVariable("key"));
 var signature = hash.toString();
 
 postman.setEnvironmentVariable("x-signature", signature);
+
 ```
 
 Note for this to work you'll have to setup your environment to have the following variables:

--- a/resources/config/signed-requests.php
+++ b/resources/config/signed-requests.php
@@ -1,59 +1,74 @@
 <?php
 
 return [
-    /*
-    |--------------------------------------------------------------------------
-    | The algorithm to sign the request with
-    |--------------------------------------------------------------------------
-    |
-    | This is the algorithm we'll use to sign the request.
-    */
-    'algorithm' => env('SIGNED_REQUEST_ALGORITHM', 'sha256'),
+    'default' => [
+        /*
+        |--------------------------------------------------------------------------
+        | The algorithm to sign the request with
+        |--------------------------------------------------------------------------
+        |
+        | This is the algorithm we'll use to sign the request.
+        */
+        'algorithm' => env('SIGNED_REQUEST_ALGORITHM', 'sha256'),
 
-    /*
-    |--------------------------------------------------------------------------
-    | The prefix to use for all of our cache values
-    |--------------------------------------------------------------------------
-    |
-    | This is the prefix we'll use for all of our keys.
-    */
-    'cache-prefix' => env('SIGNED_REQUEST_CACHE_PREFIX', 'signed-requests'),
+        /*
+        |--------------------------------------------------------------------------
+        | The prefix to use for all of our cache values
+        |--------------------------------------------------------------------------
+        |
+        | This is the prefix we'll use for all of our keys.
+        */
+        'cache-prefix' => env('SIGNED_REQUEST_CACHE_PREFIX', 'signed-requests'),
 
-    /*
-    |--------------------------------------------------------------------------
-    | Available header overrides
-    |--------------------------------------------------------------------------
-    |
-    | This allows you to customize the http headers that will be inspected to
-    | look for the signature and algorithm respectively.
-    */
-    'headers' => [
-        'signature' => env('SIGNED_REQUEST_SIGNATURE_HEADER', 'X-Signature'),
-        'algorithm' => env('SIGNED_REQUEST_ALGORITHM_HEADER', 'X-Algorithm')
+        /*
+        |--------------------------------------------------------------------------
+        | Available header overrides
+        |--------------------------------------------------------------------------
+        |
+        | This allows you to customize the http headers that will be inspected to
+        | look for the signature and algorithm respectively.
+        */
+        'headers' => [
+            'signature' => env('SIGNED_REQUEST_SIGNATURE_HEADER', 'GoodTalk-Signature'),
+            'algorithm' => env('SIGNED_REQUEST_ALGORITHM_HEADER', 'GoodTalk-Signature-Algorithm')
+        ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | The key for signing requests for verification.
+        |--------------------------------------------------------------------------
+        |
+        | This value is the key we'll use to verify signatures with. By default this
+        | key is expected from the environment. You can change this behaviour,
+        | however it is not recommended.
+        */
+        'key' => env('SIGNED_REQUEST_KEY', 'key'),
+
+        /*
+        |--------------------------------------------------------------------------
+        | Allows the management and tolerance of request replay's
+        |--------------------------------------------------------------------------
+        |
+        | This allows you to configure if the middleware should prevent the same
+        | request being replayed to your application, and adjust the tolerance
+        | for request expiry.
+        */
+        'request-replay' => [
+            'allow' => env('SIGNED_REQUEST_ALLOW_REPLAYS', false),
+            'tolerance' => env('SIGNED_REQUEST_TOLERANCE_SECONDS', 30)
+        ]
     ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | The key for signing requests for verification.
-    |--------------------------------------------------------------------------
-    |
-    | This value is the key we'll use to verify signatures with. By default this
-    | key is expected from the environment. You can change this behaviour,
-    | however it is not recommended.
-    */
-    'key' => env('SIGNED_REQUEST_KEY', 'key'),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Allows the management and tolerance of request replay's
-    |--------------------------------------------------------------------------
-    |
-    | This allows you to configure if the middleware should prevent the same
-    | request being replayed to your application, and adjust the tolerance
-    | for request expiry.
-    */
-    'request-replay' => [
-        'allow' => env('SIGNED_REQUEST_ALLOW_REPLAYS', false),
-        'tolerance' => env('SIGNED_REQUEST_TOLERANCE_SECONDS', 30)
-    ],
+    'custom' => [
+        'algorithm' => env('CUSTOM_SIGNED_REQUEST_ALGORITHM', 'sha256'),
+        'cache-prefix' => env('CUSTOM_SIGNED_REQUEST_CACHE_PREFIX', 'signed-requests'),
+        'headers' => [
+            'signature' => env('CUSTOM_SIGNED_REQUEST_SIGNATURE_HEADER', 'GoodTalk-Signature'),
+            'algorithm' => env('CUSTOM_SIGNED_REQUEST_ALGORITHM_HEADER', 'GoodTalk-Signature-Algorithm')
+        ],
+        'key' => env('CUSTOM_SIGNED_REQUEST_KEY', 'key'),
+        'request-replay' => [
+            'allow' => env('CUSTOM_SIGNED_REQUEST_ALLOW_REPLAYS', false),
+            'tolerance' => env('CUSTOM_SIGNED_REQUEST_TOLERANCE_SECONDS', 30)
+        ]
+    ]
 ];

--- a/resources/config/signed-requests.php
+++ b/resources/config/signed-requests.php
@@ -29,8 +29,8 @@ return [
         | look for the signature and algorithm respectively.
         */
         'headers' => [
-            'signature' => env('SIGNED_REQUEST_SIGNATURE_HEADER', 'GoodTalk-Signature'),
-            'algorithm' => env('SIGNED_REQUEST_ALGORITHM_HEADER', 'GoodTalk-Signature-Algorithm')
+            'signature' => env('SIGNED_REQUEST_SIGNATURE_HEADER', 'X-Signature'),
+            'algorithm' => env('SIGNED_REQUEST_ALGORITHM_HEADER', 'X-Signature-Algorithm')
         ],
 
         /*
@@ -62,8 +62,8 @@ return [
         'algorithm' => env('CUSTOM_SIGNED_REQUEST_ALGORITHM', 'sha256'),
         'cache-prefix' => env('CUSTOM_SIGNED_REQUEST_CACHE_PREFIX', 'signed-requests'),
         'headers' => [
-            'signature' => env('CUSTOM_SIGNED_REQUEST_SIGNATURE_HEADER', 'GoodTalk-Signature'),
-            'algorithm' => env('CUSTOM_SIGNED_REQUEST_ALGORITHM_HEADER', 'GoodTalk-Signature-Algorithm')
+            'signature' => env('CUSTOM_SIGNED_REQUEST_SIGNATURE_HEADER', 'X-Signature'),
+            'algorithm' => env('CUSTOM_SIGNED_REQUEST_ALGORITHM_HEADER', 'X-Signature-Algorithm')
         ],
         'key' => env('CUSTOM_SIGNED_REQUEST_KEY', 'key'),
         'request-replay' => [

--- a/run_tests
+++ b/run_tests
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Any subsequent(*) commands which fail will cause the shell script to exit immediately
+set -e
+
+echo "################################################################################";
+echo "# Running Integration Tests:"
+echo "################################################################################";
+./vendor/bin/phpunit --configuration phpunit.xml --testsuite All
+echo "################################################################################";
+echo "";

--- a/src/Exceptions/InvalidConfigurationException.php
+++ b/src/Exceptions/InvalidConfigurationException.php
@@ -16,7 +16,7 @@ class InvalidConfigurationException extends Exception implements HttpExceptionIn
     const MESSAGE = 'Failed to find Signed Requests configuration key';
 
     /**
-     * Provides a default error message for an invalid signature.
+     * Provides a default error message for an invalid configuration.
      *
      * @param string $message
      *        A customizable error message.
@@ -27,10 +27,10 @@ class InvalidConfigurationException extends Exception implements HttpExceptionIn
     }
 
     /**
-     * Returns an HTTP BAD REQUEST status code.
+     * Returns an HTTP UNPROCESSABLE ENTITY status code.
      *
      * @return int
-     *         An HTTP BAD REQUEST response status code
+     *         An HTTP UNPROCESSABLE ENTITY response status code
      */
     public function getStatusCode()
     {

--- a/src/Exceptions/InvalidConfigurationException.php
+++ b/src/Exceptions/InvalidConfigurationException.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SoapBox\SignedRequests\Exceptions;
+
+use Exception;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+
+class InvalidConfigurationException extends Exception implements HttpExceptionInterface
+{
+    /**
+     * The default exception message.
+     *
+     * @var string
+     */
+    const MESSAGE = 'Failed to find Signed Requests configuration key';
+
+    /**
+     * Provides a default error message for an invalid signature.
+     *
+     * @param string $message
+     *        A customizable error message.
+     */
+    public function __construct(string $message = self::MESSAGE)
+    {
+        parent::__construct($message);
+    }
+
+    /**
+     * Returns an HTTP BAD REQUEST status code.
+     *
+     * @return int
+     *         An HTTP BAD REQUEST response status code
+     */
+    public function getStatusCode()
+    {
+        return Response::HTTP_UNPROCESSABLE_ENTITY;
+    }
+
+    /**
+     * Returns response headers.
+     *
+     * @return array
+     *         Response headers
+     */
+    public function getHeaders()
+    {
+        return [];
+    }
+}

--- a/src/Middlewares/Laravel/VerifySignature.php
+++ b/src/Middlewares/Laravel/VerifySignature.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Config\Repository as Configurations;
 use SoapBox\SignedRequests\Exceptions\ExpiredRequestException;
 use SoapBox\SignedRequests\Exceptions\InvalidSignatureException;
+use SoapBox\SignedRequests\Exceptions\InvalidConfigurationException;
 
 class VerifySignature
 {
@@ -53,32 +54,34 @@ class VerifySignature
      *         Thrown if request replays are disabled and either the request
      *         timestamp is outside the window of tolerance, or the request has
      *         previously been served.
+     * @throws \SoapBox\SignedRequests\Exceptions\InvalidConfigurationException
+     *         Thrown if the request key is not defined in the config
      *
      * @param  \Illuminate\Http\Request $request
      *         An instance of the request.
      * @param  \Closure $next
      *         A callback function of where to go next.
-     * @param  mixed $prefix
+     * @param  mixed $requestKey
      *
      * @return mixed
      */
-    public function handle(Request $request, Closure $next, $prefix = '')
+    public function handle(Request $request, Closure $next, $requestKey = 'default')
     {
-        if (!empty($prefix)) {
-            $prefix .= '-';
+        if (!array_key_exists($requestKey, $this->configurations->get('signed-requests'))) {
+            throw new InvalidConfigurationException();
         }
 
         $signed = new Verifier($request);
 
         $key = sprintf(
             '%s.%s',
-            $this->configurations->get($prefix . 'signed-requests.cache-prefix'),
+            $this->configurations->get("signed-requests.$requestKey.cache-prefix"),
             $signed->getId()
         );
 
-        $tolerance = $this->configurations->get($prefix . 'signed-requests.request-replay.tolerance');
+        $tolerance = $this->configurations->get("signed-requests.$requestKey.request-replay.tolerance");
 
-        if (true !== $this->configurations->get($prefix . 'signed-requests.request-replay.allow')) {
+        if (true !== $this->configurations->get("signed-requests.$requestKey.request-replay.allow")) {
             $isExpired = $signed->isExpired($tolerance);
 
             if ($isExpired || $this->cache->has($key)) {
@@ -87,10 +90,10 @@ class VerifySignature
         }
 
         $signed
-            ->setSignatureHeader($this->configurations->get($prefix . 'signed-requests.headers.signature'))
-            ->setAlgorithmHeader($this->configurations->get($prefix . 'signed-requests.headers.algorithm'));
+            ->setSignatureHeader($this->configurations->get("signed-requests.$requestKey.headers.signature"))
+            ->setAlgorithmHeader($this->configurations->get("signed-requests.$requestKey.headers.algorithm"));
 
-        if (!$signed->isValid($this->configurations->get($prefix . 'signed-requests.key'))) {
+        if (!$signed->isValid($this->configurations->get("signed-requests.$requestKey.key"))) {
             throw new InvalidSignatureException();
         }
 

--- a/src/Middlewares/Laravel/VerifySignature.php
+++ b/src/Middlewares/Laravel/VerifySignature.php
@@ -58,22 +58,27 @@ class VerifySignature
      *         An instance of the request.
      * @param  \Closure $next
      *         A callback function of where to go next.
+     * @param  mixed $prefix
      *
      * @return mixed
      */
-    public function handle(Request $request, Closure $next)
+    public function handle(Request $request, Closure $next, $prefix = '')
     {
+        if (!empty($prefix)) {
+            $prefix .= '-';
+        }
+
         $signed = new Verifier($request);
 
         $key = sprintf(
             '%s.%s',
-            $this->configurations->get('signed-requests.cache-prefix'),
+            $this->configurations->get($prefix . 'signed-requests.cache-prefix'),
             $signed->getId()
         );
 
-        $tolerance = $this->configurations->get('signed-requests.request-replay.tolerance');
+        $tolerance = $this->configurations->get($prefix . 'signed-requests.request-replay.tolerance');
 
-        if (true !== $this->configurations->get('signed-requests.request-replay.allow')) {
+        if (true !== $this->configurations->get($prefix . 'signed-requests.request-replay.allow')) {
             $isExpired = $signed->isExpired($tolerance);
 
             if ($isExpired || $this->cache->has($key)) {
@@ -82,10 +87,10 @@ class VerifySignature
         }
 
         $signed
-            ->setSignatureHeader($this->configurations->get('signed-requests.headers.signature'))
-            ->setAlgorithmHeader($this->configurations->get('signed-requests.headers.algorithm'));
+            ->setSignatureHeader($this->configurations->get($prefix . 'signed-requests.headers.signature'))
+            ->setAlgorithmHeader($this->configurations->get($prefix . 'signed-requests.headers.algorithm'));
 
-        if (!$signed->isValid($this->configurations->get('signed-requests.key'))) {
+        if (!$signed->isValid($this->configurations->get($prefix . 'signed-requests.key'))) {
             throw new InvalidSignatureException();
         }
 

--- a/tests/Middlewares/Laravel/VerifySignatureTest.php
+++ b/tests/Middlewares/Laravel/VerifySignatureTest.php
@@ -181,10 +181,11 @@ class VerifySignatureTest extends TestCase
         $request = new Request($query, $request, $attributes, $cookies, $files, $server, 'a');
         $request->headers->set('signature', (string) new Signature(new Payload($request), 'sha256', 'key'));
 
-        $this->middleware->handle($request, function () {
-            // This should be called.
-            $this->assertTrue(true);
+        $called = false;
+        $this->middleware->handle($request, function () use (&$called) {
+            $called = true;
         }, 'custom');
+        $this->assertTrue($called);
     }
 
     /**


### PR DESCRIPTION
* Update `VeryifySignature::handle` to accept a prefix to allow a different set of environment variables to be loaded
* Set up your Laravel environment with a different set of signed request things
```
PREFIX_SIGNED_REQUEST_ALGORITHM=sha256
PREFIX_SIGNED_REQUEST_CACHE_PREFIX=signed-requests
PREFIX_SIGNED_REQUEST_SIGNATURE_HEADER=The-Signature
PREFIX_SIGNED_REQUEST_ALGORITHM_HEADER=The-Signature-Algorithm
PREFIX_SIGNED_REQUEST_KEY=newSecretKey007
PREFIX_SIGNED_REQUEST_ALLOW_REPLAYS=true
PREFIX_SIGNED_REQUEST_TOLERANCE_SECONDS=600
```
* Update the `signed-requests.php` configuration
```
    'webhooks' => [
        'algorithm' => env('PREFIX_SIGNED_REQUEST_ALGORITHM', 'sha256'),
        'cache-prefix' => env('PREFIX_SIGNED_REQUEST_CACHE_PREFIX', 'signed-requests'),
        'headers' => [
            'signature' => env('PREFIX_SIGNED_REQUEST_SIGNATURE_HEADER', 'GoodTalk-Signature'),
            'algorithm' => env('PREFIX_SIGNED_REQUEST_ALGORITHM_HEADER', 'GoodTalk-Signature-Algorithm')
        ],
        'key' => env('PREFIX_SIGNED_REQUEST_KEY', 'key'),
        'request-replay' => [
            'allow' => env('PREFIX_SIGNED_REQUEST_ALLOW_REPLAYS', false),
            'tolerance' => env('PREFIX_SIGNED_REQUEST_TOLERANCE_SECONDS', 30)
        ]
    ]
```

* Set up the route to pass the prefix
```
$api->group(['middleware' => 'verify-signature:prefix'], function ($api) {
            $api->group(['prefix' => 'webhook', 'namespace' => 'Webhooks'], function($api) {
                $api->post('sync', ['uses' => 'Sync@store']);
            });
        });
```

- [ ] We did it reddit